### PR TITLE
Fix bug resulting in dates showing as hash on space#show

### DIFF
--- a/app/views/spaces/show.html.erb
+++ b/app/views/spaces/show.html.erb
@@ -10,8 +10,8 @@
   <%= form_tag(reservations_path, method: "post") do %>
     <p class="price">Nightly Rate: <%= number_to_currency(@space.price) %></p><br>
     <p>
-      Check in Date: <%= text_field_tag "start_date", value: @search_hash[:start_date], placeholder: "yyyy/mm/dd", class: "form-control", id: "datepicker-checkin" %><br><br>
-      Check out Date: <%= text_field_tag "end_date", value: @search_hash[:end_date], placeholder: "yyyy/mm/dd", class: "form-control", id: "datepicker-checkout" %><br><br>
+      Check in Date: <%= text_field_tag "start_date", @search_hash[:start_date], placeholder: "yyyy/mm/dd", class: "form-control", id: "datepicker-checkin" %><br><br>
+      Check out Date: <%= text_field_tag "end_date", @search_hash[:end_date], placeholder: "yyyy/mm/dd", class: "form-control", id: "datepicker-checkout" %><br><br>
       Occupancy: <%= @space.occupancy %><br><br>
       Planet: <%= @space.planet.name %><br><br>
       Style: <%= @space.style.name %><br><br>


### PR DESCRIPTION
Adjusted the display of search params on Space#Show to display accurately. The prior merge resulted in the dates showing as a full hash due to a bad copy paste.
